### PR TITLE
Add option to disable WebKit hardware acceleration

### DIFF
--- a/com.cassidyjames.butler.Devel.json
+++ b/com.cassidyjames.butler.Devel.json
@@ -9,7 +9,8 @@
     "--socket=fallback-x11",
     "--share=ipc",
     "--share=network",
-    "--device=dri"
+    "--device=dri",
+    "--talk-name=org.freedesktop.Flatpak"
   ],
   "modules": [
     {

--- a/com.cassidyjames.butler.json
+++ b/com.cassidyjames.butler.json
@@ -9,7 +9,8 @@
     "--socket=fallback-x11",
     "--share=ipc",
     "--share=network",
-    "--device=dri"
+    "--device=dri",
+    "--talk-name=org.freedesktop.Flatpak"
   ],
   "modules": [
     {

--- a/data/gschema.xml.in
+++ b/data/gschema.xml.in
@@ -21,6 +21,11 @@
       <summary>Header colors</summary>
       <description>Colors for the header bar to better integrate into custom servers, stored as a (light, dark) pair to be used according to the system color scheme preference</description>
     </key>
+    <key name="hardware-acceleration" type="b">
+      <default>true</default>
+      <summary>Hardware acceleration</summary>
+      <description>Whether WebKitGTK hardware acceleration should be enabled, or disabled to avoid excessive GPU or memory use on certain hardware</description>
+    </key>
     <key name="server" type="s">
       <default>"https://demo.home-assistant.io/"</default>
       <summary>Home Assistant server URL</summary>

--- a/data/metainfo.xml.in
+++ b/data/metainfo.xml.in
@@ -87,6 +87,11 @@
   </screenshots>
 
   <releases>
+    <release version="1.8.0" date="2026-08-20">
+      <description>
+        <p>New option to disable hardware acceleration which can help performance on some hardware</p>
+      </description>
+    </release>
     <release version="1.7.0" date="2026-05-27">
       <description>
         <p>Auto-hiding title bar</p>

--- a/data/ui/main-window.blp
+++ b/data/ui/main-window.blp
@@ -206,5 +206,11 @@ template $ButlerMainWindow : Adw.ApplicationWindow {
       action-name: "win.settings";
       button-label: _("Change _Server…");
     }
+
+    Adw.Banner restart_banner {
+      title: _("Restart Butler to Apply Changes");
+      action-name: "app.restart";
+      button-label: _("_Restart");
+    }
   };
 }

--- a/data/ui/settings-dialog.blp
+++ b/data/ui/settings-dialog.blp
@@ -74,5 +74,23 @@ template $ButlerSettingsDialog : Adw.PreferencesDialog {
         subtitle: _("Mouse or tap near the top of the window to reveal");
       }
     }
+
+    Adw.PreferencesGroup {
+      title: _("Performance");
+
+      [header-suffix]
+      Gtk.Button performance_reset_button {
+        icon-name: "step-back-symbolic";
+        tooltip-text: _("Reset to Default");
+        valign: center;
+
+        styles ["flat"]
+      }
+
+      Adw.SwitchRow hardware_acceleration_row {
+        title: _("Hardware Acceleration");
+        subtitle: _("Disabling may reduce resource usage on some hardware; restart required");
+      }
+    }
   }
 }

--- a/data/ui/settings-dialog.blp
+++ b/data/ui/settings-dialog.blp
@@ -89,7 +89,7 @@ template $ButlerSettingsDialog : Adw.PreferencesDialog {
 
       Adw.SwitchRow hardware_acceleration_row {
         title: _("Hardware Acceleration");
-        subtitle: _("Disabling may reduce resource usage on some hardware; restart required");
+        subtitle: _("Disabling may reduce resource usage on some hardware, but can cause other issues; restart required");
       }
     }
   }

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'com.cassidyjames.butler',
   'vala', 'c',
-  version: '1.7.0',
+  version: '1.8.0',
   meson_version: '>=1.5.1',
 )
 

--- a/src/App.vala
+++ b/src/App.vala
@@ -27,6 +27,10 @@ public class Butler.App : Adw.Application {
         quit_action.activate.connect (quit);
         add_action (quit_action);
 
+        var restart_action = new SimpleAction ("restart", null);
+        restart_action.activate.connect (restart);
+        add_action (restart_action);
+
         set_accels_for_action ("app.quit", {"<Ctrl>Q"});
         set_accels_for_action ("win.zoom-in", {"<Ctrl>plus", "<Ctrl>equal"});
         set_accels_for_action ("win.zoom-default", {"<Ctrl>0"});
@@ -34,6 +38,29 @@ public class Butler.App : Adw.Application {
         set_accels_for_action ("win.reload", {"<Ctrl>R"});
         set_accels_for_action ("win.toggle_fullscreen", {"F11"});
         set_accels_for_action ("win.settings", {"<Ctrl>comma"});
+    }
+
+    private void restart () {
+        try {
+            // Flatpak kills every process once the first one exits, so use
+            // `flatpak-spawn` to launch a new instance of the app instead.
+            if (Environment.get_variable ("FLATPAK_ID") != null) {
+                Process.spawn_async (null,
+                    { "flatpak-spawn", "--host", "flatpak", "run", APP_ID },
+                    null, SpawnFlags.SEARCH_PATH, null, null
+                );
+            } else {
+                Process.spawn_async (null,
+                    { "/proc/self/exe" },
+                    null, 0, null, null
+                );
+            }
+        } catch (SpawnError e) {
+            warning ("Unable to restart Butler: %s", e.message);
+            return;
+        }
+
+        quit ();
     }
 
     public static int main (string[] args) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -29,6 +29,7 @@ public class Butler.MainWindow : Adw.ApplicationWindow {
     [GtkChild] private unowned Adw.ToastOverlay toast_overlay;
     [GtkChild] private unowned Gtk.Button open_button;
     [GtkChild] private unowned Adw.Banner demo_banner;
+    [GtkChild] private unowned Adw.Banner restart_banner;
     [GtkChild] private unowned Gtk.Stack stack;
     [GtkChild] private unowned Adw.StatusPage loading_page;
     [GtkChild] private unowned Adw.StatusPage error_page;
@@ -303,6 +304,9 @@ public class Butler.MainWindow : Adw.ApplicationWindow {
         add_action (fullscreen_action);
 
         App.settings.changed["autohide-titlebar"].connect (update_header_visibility);
+        App.settings.changed["hardware-acceleration"].connect (() => {
+            restart_banner.revealed = true;
+        });
         notify["fullscreened"].connect (() => {
             fullscreen_action.set_state (new GLib.Variant.boolean (fullscreened));
             update_header_visibility ();

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -10,8 +10,10 @@ public class Butler.SettingsDialog : Adw.PreferencesDialog {
     [GtkChild] private unowned Gtk.ColorDialogButton color_light_button;
     [GtkChild] private unowned Gtk.ColorDialogButton color_dark_button;
     [GtkChild] private unowned Gtk.Button styling_reset_button;
+    [GtkChild] private unowned Gtk.Button performance_reset_button;
     [GtkChild] private unowned Adw.SwitchRow expressive_row;
     [GtkChild] private unowned Adw.SwitchRow autohide_row;
+    [GtkChild] private unowned Adw.SwitchRow hardware_acceleration_row;
 
     public signal void server_changed ();
     public signal void colors_changed (string light, string dark);
@@ -74,11 +76,21 @@ public class Butler.SettingsDialog : Adw.PreferencesDialog {
             color_dark_button.rgba = dark_rgba;
         });
 
+        performance_reset_button.clicked.connect (() => {
+            App.settings.reset ("hardware-acceleration");
+        });
+
         color_light_button.notify["rgba"].connect (on_color_button_change);
         color_dark_button.notify["rgba"].connect (on_color_button_change);
 
         App.settings.bind ("expressive-styling", expressive_row, "active", SettingsBindFlags.DEFAULT);
         App.settings.bind ("autohide-titlebar", autohide_row, "active", SettingsBindFlags.DEFAULT);
+        App.settings.bind (
+            "hardware-acceleration",
+            hardware_acceleration_row,
+            "active",
+            SettingsBindFlags.DEFAULT
+        );
     }
 
     private void on_color_button_change () {

--- a/src/Widgets/WebView.vala
+++ b/src/Widgets/WebView.vala
@@ -33,6 +33,10 @@ public class Butler.WebView : WebKit.WebView {
             enable_webrtc = true
         };
 
+        if (App.settings.get_boolean ("hardware-acceleration") == false) {
+            webkit_settings.hardware_acceleration_policy = WebKit.HardwareAccelerationPolicy.NEVER;
+        }
+
         settings = webkit_settings;
 
         var cookie_manager = network_session.get_cookie_manager ();


### PR DESCRIPTION
## Summary

Adds a new Performance setting for WebKitGTK hardware acceleration so users who see excessive GPU or system memory usage from `WebKitWebProcess` can turn it off.

The default behavior remains unchanged: hardware acceleration stays enabled by default. When the new **Hardware Acceleration** setting is turned off, Butler sets `WebKit.Settings.hardware_acceleration_policy` to `WebKit.HardwareAccelerationPolicy.NEVER` before assigning the settings to the web view.

Refs #90
Refs #59

## Why

On an AMD Radeon PRO WX 3200 system using KDE Wayland, Butler/WebKitGTK could allocate roughly 11-13 GiB of AMD GTT system memory while open. Closing Butler immediately dropped `/sys/class/drm/card1/device/mem_info_gtt_used` to roughly 256 MiB. This gives affected users a native workaround without changing behavior for everyone else.

## Testing

- `flatpak-builder --force-clean --install-deps-from=flathub build-dir com.cassidyjames.butler.Devel.json`
- `git diff --check`
- Verified the new GSettings key appears in the built devel schema with `flatpak-builder --run build-dir com.cassidyjames.butler.Devel.json gsettings list-keys com.cassidyjames.butler.Devel`
- Started the devel app briefly with `hardware-acceleration` set to `false`; AMD GTT stayed around 100-116 MiB in that startup smoke test
