### PR TITLE
Fix WebView lifecycle warnings and prevent crash on SPA redirects

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -419,21 +419,6 @@ public class Butler.MainWindow : Adw.ApplicationWindow {
             demo_banner.revealed = false;
             home_revealer.reveal_child = true;
         }
-
-        web_view.evaluate_javascript.begin (
-            "document.querySelector('home-assistant, ha-authorize') !== null",
-            -1, null, null, null,
-            (obj, res) => {
-                try {
-                    var js_result = web_view.evaluate_javascript.end (res);
-                    if (!js_result.to_boolean ()) {
-                        stack.visible_child_name = "not-ha";
-                    }
-                } catch (Error e) {
-                    // Ignore JS errors; leave page visible
-                }
-            }
-        );
     }
 
     private void zoom_in () {

--- a/src/Widgets/WebView.vala
+++ b/src/Widgets/WebView.vala
@@ -17,9 +17,7 @@ public class Butler.WebView : WebKit.WebView {
                 Path.build_path (Path.DIR_SEPARATOR_S, Environment.get_user_cache_dir (), Environment.get_prgname ())
             )
         );
-    }
 
-    construct {
         is_terminal = Posix.isatty (Posix.STDIN_FILENO);
 
         var webkit_settings = new WebKit.Settings () {


### PR DESCRIPTION
This PR fixes two stability issues in Butler:

1. **WebView construction lifecycle bug** (in `WebView.vala`): Moves parent network_session and cookie manager initialization from construct block to the constructor body, resolving GLib critical assertion warnings on startup.
2. **Crash on SPA redirects** (in `MainWindow.vala`): Completely removes the evaluate_javascript DOM check that ran on every FINISHED load event. This check caused segmentation faults when loading Home Assistant dashboards due to the JS context getting destroyed during SPA redirects, and caused false-positive page blocks on slow renders.